### PR TITLE
Image "Jumping" When Using Transitions

### DIFF
--- a/jquery.backstretch.js
+++ b/jquery.backstretch.js
@@ -103,7 +103,7 @@
                     if(settings.centeredX) $.extend(bgCSS, {left: "-" + bgOffset + "px"});
                 }
 
-                $("#backstretch, #backstretch img").width( bgWidth ).height( bgHeight )
+                $("#backstretch, #backstretch img:not(.deleteable)").width( bgWidth ).height( bgHeight )
                                                    .filter("img").css(bgCSS);
             } catch(err) {
                 // IE7 seems to trigger _adjustBG before the image is loaded.


### PR DESCRIPTION
Applied :not() to the jQuery selector in the adjustBg() function to prevent fading images from giving the impression they are "jumping".
