### PR TITLE
Backstretch also as amd/commonjs module.

### DIFF
--- a/jquery.backstretch.js
+++ b/jquery.backstretch.js
@@ -25,6 +25,8 @@
 
 })( 'backstretch', function() {
 
+  var backstretch;
+
   (function($) {
 
     backstretch = $.backstretch = function(src, options, callback) {


### PR DESCRIPTION
This changes makes it possible to use backstretch as normal jQuery plugin but also as amd/commonjs module. With jQuery 1.7.x the amd specs. are also introduced to jQuery itself :-).

I just add this amd/commonjs pattern (Seems to be a common one):

https://github.com/addyosmani/jquery-plugin-patterns/blob/master/amd+commonjs/pluginCore.js

In my case it works perfect with requireJS ;-).

Greets,
Sascha
