### PR TITLE
Backstretch as normal plugin and also as AMD module.

### DIFF
--- a/jquery.backstretch.js
+++ b/jquery.backstretch.js
@@ -114,5 +114,11 @@
             if (typeof fn == "function") fn();
         }
     };
-  
+    
+    // Expose backstretch as an AMD module
+    // https://github.com/jquery/jquery/blob/master/src/exports.js
+    if ( typeof define === "function" && define.amd ){
+        define("backstretch", [], function () { return $.backstretch; });
+    }
+
 })(jQuery);


### PR DESCRIPTION
Hey there,

as i can see these three lines of code i added just works fine. I tested it as normal plugin and as upcoming amd module.

As normal plugin it still works as usual: $.backstretch(....);

As AMD module within some main.js file:

define('main', ['backstretch'], function(backstretch){
    backstretch(....);
});

I hope this works now.

Greets,
Sascha
