### PR TITLE
Adding a fix for images max-height inheritance.

### DIFF
--- a/src/jquery.backstretch.js
+++ b/src/jquery.backstretch.js
@@ -92,6 +92,7 @@
         , border: 'none'
         , width: 'auto'
         , height: 'auto'
+        , maxHeight: 'none'
         , maxWidth: 'none'
         , zIndex: -999999
       }


### PR DESCRIPTION
Hey Scott,

While using this on a responsive site, I needed to set max-height on images globally. Doing so, broke the scaling ratio for images using Backstretch. I just added a style to reset "max-height" to "none".
