### PR TITLE
Fixed an issue with destroy.

### DIFF
--- a/jquery.backstretch.js
+++ b/jquery.backstretch.js
@@ -32,7 +32,9 @@
         options = $.extend(obj.options, options);
 
         // Remove the old instance
-        obj.destroy(true);
+        if ( obj.hasOwnProperty('destroy') ) {
+          obj.destroy(true);
+        }
       }
 
       obj = new Backstretch(this, images, options);


### PR DESCRIPTION
Check if the obj variable has a method called 'destroy' before calling it.
Without this, I kept getting an error saying:
http://site.com/img/image.jpg has no method 'destroy'.
