### PR TITLE
added bower json file

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -11,7 +11,7 @@
   "version": "2.0.3",
   "main": ["jquery.backstretch.js"],
   "dependencies": {
-    "jquery": "~1.8.3"
+    "jquery": "~1.9.1"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
using the `main` attribute in bower.json so tools like [grunt-bower-requirejs](https://github.com/yeoman/grunt-bower-requirejs) can consume backstretch.
