### PR TITLE
Adding a timeout before showing the first image, through new 'timeout' option

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@ Include the jQuery library (version 1.7 or newer) and Backstretch plugin files i
     "path/to/image2.jpg",
     "path/to/image3.jpg"    
   ], {duration: 4000});
+
+  // To wait some time before showing the first image, you set a timeout
+  $.backstretch("path/to/image.jpg", {
+    timeout: 2000,
+  });
 </script>
 ```
 
@@ -36,6 +41,7 @@ Include the jQuery library (version 1.7 or newer) and Backstretch plugin files i
 | `centeredY` | This parameter controls whether or not we center the image on the Y axis to account for the aforementioned discrepancy. | Boolean | true |
 | `fade` | This is the speed at which the image will fade in. Integers in milliseconds are accepted, as well as standard jQuery speed strings (slow, normal, fast). | Integer or String | 0 |
 | `duration` | The amount of time in between slides, when using Backstretch as a slideshow, expressed as the number of milliseconds. | Integer | 5000 |
+| `timeout` | The amount of time to wait before the first image is shown, expressed as the number of milliseconds. | Integer | 0 |
 
 ## Slideshow API
 

--- a/examples/timeout.html
+++ b/examples/timeout.html
@@ -1,0 +1,68 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <style>
+        body { font-family: Helvetica, Arial, sans-serif; line-height: 1.3em; -webkit-font-smoothing: antialiased; }
+        .container {
+            width: 90%;
+            margin: 20px auto;
+            background-color: #FFF;
+            padding: 20px;
+        }
+
+        pre, code {
+            font-family: Monaco, Menlo, Consolas, "Courier New", monospace;
+            font-size: 12px;
+            color: #333;
+            -webkit-border-radius: 3px;
+            -moz-border-radius: 3px;
+            border-radius: 3px;
+        }
+        pre { border: 1px solid #CCC; background-color: #EEE; color: #333; padding: 10px; overflow: scroll; }
+        code { padding: 2px 4px; background-color: #F7F7F9; border: 1px solid #E1E1E8; color: #D14; }
+
+        .other { height: 300px; color: #FFF; }
+        .other div {
+            position: absolute;
+            bottom: 0;
+            width: 100%;
+            background: #000;
+            background: rgba(0,0,0,0.7);
+        }
+        .other div p { padding: 10px; }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>Timeout Demo</h1>
+        <p>When a timeout is specified, the first image will be shown after the timeout is complete.
+                <pre>&lt;script src=&quot;//ajax.googleapis.com/ajax/libs/jquery/1.8.3/jquery.min.js&quot;&gt;&lt;/script&gt;
+    &lt;script src=&quot;jquery.backstretch.min.js&quot;&gt;&lt;/script&gt;
+    &lt;script&gt;
+        $.backstretch([
+          &quot;pot-holder.jpg&quot;,
+          &quot;coffee.jpg&quot;,
+          &quot;dome.jpg&quot;
+          ], {
+            fade: 750,
+            duration: 4000,
+            timeout: 3000
+          });
+    &lt;/script&gt;</pre>
+    </div>
+    <script src="../libs/jquery/jquery.js"></script>
+    <script src="../src/jquery.backstretch.js"></script>
+    <script>
+        $.backstretch([
+            "pot-holder.jpg",
+            "coffee.jpg",
+            "dome.jpg"
+        ], {
+            fade: 750,
+            duration: 3000,
+            timeout: 3000
+        });
+    </script>
+</body>
+</html>

--- a/src/jquery.backstretch.js
+++ b/src/jquery.backstretch.js
@@ -75,6 +75,7 @@
     , centeredY: true   // Should we center the image on the Y axis?
     , duration: 5000    // Amount of time in between slides (if slideshow)
     , fade: 0           // Speed of fade transition between slides
+    , timeout: 0        // Amount of time to wait before the first image is shown
   };
 
   /* STYLES
@@ -164,7 +165,11 @@
 
     // Set the first image
     this.index = 0;
-    this.show(this.index);
+
+    // Show first image after the timeout
+    setTimeout($.proxy(function () {
+      this.show(this.index);
+    }, this), this.options.timeout);
 
     // Listen for resize
     $(window).on('resize.backstretch', $.proxy(this.resize, this))


### PR DESCRIPTION
I've needed this feature and maybe someone might find it usefull too.

I've added a new option called 'timeout' that sets the time to wait before showing the first image.

It can be used with/out both 'fade' and 'duration' options (so the fade will trigger after the timeout)

In any case, thank you for this great plugin!
