### PR TITLE
updated jquery version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -11,7 +11,7 @@
   "version": "2.0.4",
   "main": ["jquery.backstretch.js"],
   "dependencies": {
-    "jquery": "~1.9.1"
+    "jquery": ">=1.9.x"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
I think it should work just fine with both versions, right? >= 1.9
I'm using this way and it seems to be fine. ( with jquery 2.1.3 )
