### PR TITLE
Markup: Add alt attribute to image element

### DIFF
--- a/jquery.backstretch.js
+++ b/jquery.backstretch.js
@@ -234,6 +234,7 @@
 
         // New image
         self.$img = $('<img />')
+                      .attr('alt', '')
                       .css(styles.img)
                       .bind('load', function (e) {
                         var imgWidth = this.width || $(e.target).width()


### PR DESCRIPTION
Valid HTML 4 and HTML5 markup requires that `img` elements have an `alt` attribute.

Since the backstretch image is purely decorative, an `alt` value of an empty string is correct - screen readers will skip over it completely, as it's not a critical part of the content.

Having valid markup, particularly `alt` attribute on images, is one of the easily-testable checks that most accessibility validators will check for. Fixing this is therefore key to helping developers reduce the warnings they get on code they can't otherwise edit.

Fixes #437, updates #292
